### PR TITLE
Fix usage of AC_ARG_WITH

### DIFF
--- a/m4/gl.m4
+++ b/m4/gl.m4
@@ -7,11 +7,11 @@ AC_REQUIRE([AC_PROG_CC])
 AC_REQUIRE([AC_PATH_X])
 AC_REQUIRE([AC_PATH_XTRA])
 
-AC_ARG_WITH([--with-gl-inc],
+AC_ARG_WITH([gl-inc],
     AC_HELP_STRING([--with-gl-inc=DIR],[Directory where GL/gl.h is installed]))
-AC_ARG_WITH([--with-gl-lib],
+AC_ARG_WITH([gl-lib],
     AC_HELP_STRING([--with-gl-lib=DIR],[Directory where OpenGL libraries are installed]))
-AC_ARG_WITH([--with-glu-lib],
+AC_ARG_WITH([glu-lib],
     AC_HELP_STRING([--with-glu-lib=DIR],[Directory where OpenGL GLU library is installed]))
 
 AC_LANG_SAVE

--- a/m4/glut.m4
+++ b/m4/glut.m4
@@ -8,9 +8,9 @@ AC_REQUIRE([AC_PATH_X])dnl
 AC_REQUIRE([AC_PATH_XTRA])dnl
 AC_REQUIRE([FTGL_CHECK_GL])dnl
 
-AC_ARG_WITH([--with-glut-inc],
+AC_ARG_WITH([glut-inc],
     AC_HELP_STRING([--with-glut-inc=DIR],[Directory where GL/glut.h is installed (optional)]))
-AC_ARG_WITH([--with-glut-lib],
+AC_ARG_WITH([glut-lib],
     AC_HELP_STRING([--with-glut-lib=DIR],[Directory where GLUT libraries are installed (optional)]))
 
 AC_LANG_SAVE


### PR DESCRIPTION
Use `AC_ARG_WITH` correctly so that the advertised configure options actually exist under their expected names.

`./configure --help` claims that the following options exist:
```
  --with-gl-inc=DIR       Directory where GL/gl.h is installed
  --with-gl-lib=DIR       Directory where OpenGL libraries are installed
  --with-glu-lib=DIR      Directory where OpenGL GLU library is installed
  --with-glut-inc=DIR     Directory where GL/glut.h is installed (optional)
  --with-glut-lib=DIR     Directory where GLUT libraries are installed
                          (optional)
```
but they don't:
```
./configure --with-gl-inc=/tmp --with-gl-lib=/tmp --with-glu-lib=/tmp --with-glut-inc=/tmp --with-glut-lib=/tmp
Password:
configure: WARNING: unrecognized options: --with-gl-inc, --with-gl-lib, --with-glu-lib, --with-glut-inc, --with-glut-lib
^C
```

This is happening because `AC_ARG_WITH` is used incorrectly. In fact, as currently written, the configure script honors these unexpectedly named options:

* `--with---with-gl-inc`
* `--with---with-gl-lib`
* `--with---with-glu-lib`
* `--with---with-glut-inc`
* `--with---with-glut-lib` 

This PR fixes the problem by calling `AC_ARG_WITH` correctly.

I am aware that you are no longer maintaining ftgl, but since this is still the latest upstream for ftgl that I am aware of, I am submitting this bug fix here.