### PR TITLE
Use correct syntax for the -dylib_file flag

### DIFF
--- a/m4/gl.m4
+++ b/m4/gl.m4
@@ -50,7 +50,7 @@ LIBS="$LIBS -Xlinker -framework -Xlinker OpenGL"
 # -Xlinker is used because libtool is busted prior to 1.6 wrt frameworks
 AC_TRY_LINK([#include <OpenGL/gl.h>], [glBegin(GL_POINTS)],
     [GL_DYLIB="/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib"
-     FRAMEWORK_OPENGL="-Xlinker -framework -Xlinker OpenGL -dylib_file $GL_DYLIB: $GL_DYLIB"
+     FRAMEWORK_OPENGL="-Xlinker -framework -Xlinker OpenGL -dylib_file $GL_DYLIB:$GL_DYLIB"
      ac_cv_search_glBegin="$FRAMEWORK_OPENGL"
      AC_MSG_RESULT(yes)],
     [AC_MSG_RESULT(no)])


### PR DESCRIPTION
Use correct syntax for the `-dylib_file` flag (no space after colon). Fixes configure failure on macOS Big Sur and later:

```
configure: error: GL library could not be found, please specify its location with --with-gl-lib.
```

config.log contains:

```
configure:17551: /usr/bin/clang -o conftest -pipe -Os -DGL_SILENCE_DEPRECATION -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk -arch x86_64  -L/opt/local/lib -Wl,-headerpad_max_install_names -Wl,-syslibroot,/Library/Developer/CommandLineTools/SDKs/MacOSX11.0.sdk -arch x86_64 conftest.c -Xlinker -framework -Xlinker OpenGL -dylib_file /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib: /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib >&5
clang: error: no such file or directory: '/System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib'
```

Because of the erroneous space after the colon, this configure test was actually trying to operate on the file /System/Library/Frameworks/OpenGL.framework/Versions/A/Libraries/libGL.dylib. This must have silently worked before because that file did exist, but as of macOS Big Sur, that and all other system dylibs no longer exist in the filesystem. (They only exist in what Apple calls the dylib cache.)