### PR TITLE
Fix type mismatch with latest FreeType

### DIFF
--- a/src/FTVectoriser.cpp
+++ b/src/FTVectoriser.cpp
@@ -168,7 +168,7 @@ void FTVectoriser::ProcessContours()
     for(int i = 0; i < ftContourCount; ++i)
     {
         FT_Vector* pointList = &outline.points[startIndex];
-        char* tagList = &outline.tags[startIndex];
+        char* tagList = (char*)&outline.tags[startIndex];
 
         endIndex = outline.contours[i];
         contourLength =  (endIndex - startIndex) + 1;


### PR DESCRIPTION
This change is intrumented due to a type change in freetype [1] with release 2.13.3

Fixes
| ../../git/src/FTVectoriser.cpp:171:15: error: cannot initialize a variable of type 'char *' with an rvalue of type 'unsigned char *'
|   171 |         char* tagList = &outline.tags[startIndex];
|       |               ^         ~~~~~~~~~~~~~~~~~~~~~~~~~

[1] https://gitlab.freedesktop.org/freetype/freetype/-/commit/044d142be7b6a93b6940367a1bc5847451ff4775